### PR TITLE
1.20.1/2 Support

### DIFF
--- a/src/main/resources/rusherhack-plugin.json
+++ b/src/main/resources/rusherhack-plugin.json
@@ -7,6 +7,8 @@
     "xyzbtw"
   ],
   "Minecraft-Versions": [
+    "1.20.1",
+    "1.20.2",
     "1.20.4"
   ]
 }


### PR DESCRIPTION
This adds support for 1.20.1 and 1.20.2

I tried to add 1.20.5+ support, but Minecraft switched from NBT tags to Components, which are both systems I don't understand and couldn't figure out how to update.

When this plugin is updated to 1.20.5+ a separate branch (for 1.20) should be made before merging 1.20.5+, because it would be compatible with 1.20.5/6 & 1.21.